### PR TITLE
Adding graduation banner to Command Palette chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@
 
 [Netlify Labs](https://www.netlify.com/blog/2021/03/31/test-drive-netlify-beta-features-with-netlify-labs/) gives you early access to new features before they’re available to everyone. We welcome your feedback, and we encourage you to join the [Netlify research program](https://www.netlify.com/research-program/) to help us continuously improve the platform. Experimental features are works-in-progress, so you may find some bugs along the way.
 
-## Features in Labs
+## Features currently in Labs
 
 * [Netlify Graph](features/graph/documentation/)
-* [Command Palette](features/command-palette/)
 * [Scheduled Functions](features/scheduled-functions/documentation/README.md)
+
+## Features graduated from Labs
+
+* [Command Palette](features/command-palette/)

--- a/features/command-palette/README.md
+++ b/features/command-palette/README.md
@@ -1,6 +1,6 @@
 # Command Palette
 
-> **NOTE:** This feature is in opt-in BETA, released through [Netlify Labs](https://www.netlify.com/blog/2021/03/31/test-drive-netlify-beta-features-with-netlify-labs/). Its functionality is subject to change.
+> **NOTE:** This feature originated in Labs, and is now generally available for all users. The content of this readme pertains to the original Labs launch, and is archived here for posterity. For up-to-date documentation about the Command Palette, head over to [the docs](https://docs.netlify.com/welcome/command-palette/). 
 
 The Command Palette is a power tool that gives you quick navigation through the Netlify UI and access to various commands. Use it by pressing <kbd>CTRL</kbd> + <kbd>K</kbd> on Windows or Linux (or <kbd>CMD</kbd> + <kbd>K</kbd> on macOS), or by selecting the magnifying glass icon in the navigation header. 
 


### PR DESCRIPTION
This PR updates the banner at the top of the Command Palette chapter, pointing to the [new location in docs](https://docs.netlify.com/welcome/command-palette/). 