### PR TITLE
update with link to the gravity repo

### DIFF
--- a/features/graph/documentation/README.md
+++ b/features/graph/documentation/README.md
@@ -34,7 +34,7 @@ npm install netlify-cli -g
 ## Example repo and tutorial
 
 <!-- TODO: Update this section with link to the gravity repo -->
-If you'd like to try Netlify Graph in a test project, check out the `gravity` sample repo. It has a full tutorial that walks you through getting the `gravity` site running on Netlify to creating and using GraphQL queries.
+If you'd like to try Netlify Graph in a test project, check out the [gravity](https://github.com/dend/gravity) sample repo. It has a full tutorial that walks you through getting the [gravity](https://github.com/dend/gravity) site running on Netlify to creating and using GraphQL queries.
 
 ## Get started with Netlify Graph
 


### PR DESCRIPTION
The link is not easy to find. It should be available right away, especially that this page is linked from the official announcement.

I would also consider moving this sample repo under the @netlify org