### PR TITLE
Add Lighthouse to Labs README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 * [Netlify Graph](features/graph/documentation/)
 * [Scheduled Functions](features/scheduled-functions/documentation/README.md)
+* [Lighthouse Score Visualizations](/features/lighthouse-visualizations/documentation/README.md)
 
 ## Features graduated from Labs
 


### PR DESCRIPTION
Improves visibility of Lighthouse docs page by mentioning Lighthouse in Labs `README.md`. 