### PR TITLE
docs: Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 		<b>Documentation and samples for features released through Netlify Labs</b>
 	</p>
 	<br>
-	<br>
-	<br>
 </div>
+
+> **Note:** The content in this repository is deprecated. To access up-to-date documentation and provide feedback on features in [Netlify Labs](https://app.netlify.com/user/labs), visit the Labs section of the [Netlify docs](https://docs.netlify.com/netlify-labs/experimental-features/).
+
+- - -
 
 [Netlify Labs](https://www.netlify.com/blog/2021/03/31/test-drive-netlify-beta-features-with-netlify-labs/) gives you early access to new features before they’re available to everyone. We welcome your feedback, and we encourage you to join the [Netlify research program](https://www.netlify.com/research-program/) to help us continuously improve the platform. Experimental features are works-in-progress, so you may find some bugs along the way.
 


### PR DESCRIPTION
This PR adds a notice to the README that points users to a more up-to-date set of documentation and feedback mechanisms for each labs feature.

This repo is set to be archived now that Netlify Labs has a section in the main Netlify docs site.

To review the content in context: https://github.com/netlify/labs/tree/rms/readme-update-pre-archiving